### PR TITLE
fix 'bad value for range' in inline templates 

### DIFF
--- a/manifests/create_homedirs.pp
+++ b/manifests/create_homedirs.pp
@@ -5,7 +5,7 @@ define grid_accounts::create_homedirs($home_path = "", $dirs = {}){
 ---
 <% @dirs.each_pair do |fqan, data |
    next if data["ensure"] == "absent" %>
-  <% (1..data["users_num"]).each do |i| %>
+  <% (1..data["users_num"].to_i).each do |i| %>
     <% user = sprintf("%s%#03i",data["group"],i) %>
     <%= user %>:
       ensure: "directory"

--- a/manifests/create_users.pp
+++ b/manifests/create_users.pp
@@ -7,7 +7,7 @@ define grid_accounts::create_users( $home_path = "/home", $users = {}){
    next if data["ensure"] == "absent" %>
   <% uid_fl = data["uid_range"].split("-");
      uids = (uid_fl[0]..uid_fl[1]).to_a;
-     (1..data["users_num"]).each do |i| %>
+     (1..data["users_num"].to_i).each do |i| %>
   <% user = sprintf("%s%#03i",data["group"],i) %>
     <%= user %>:
        ensure: <%= data["ensure"] %>


### PR DESCRIPTION
puppet complains about 'bad value for range' while interpreting value of data["users_num"] otherwise.